### PR TITLE
Invalidate LinkStub after ten uses

### DIFF
--- a/server/src/main/java/net/wasicek/linkstub/models/LinkStub.java
+++ b/server/src/main/java/net/wasicek/linkstub/models/LinkStub.java
@@ -26,9 +26,12 @@ public class LinkStub {
     @CreationTimestamp
     private Instant createdOn;
 
+    private int numTimesUsed;
+
     public LinkStub(String originalUrl) {
         HashCode hashCode = Hashing.murmur3_32().hashString(originalUrl, StandardCharsets.UTF_8);
         this.urlHash = hashCode.toString();
         this.originalUrl = originalUrl;
+        this.numTimesUsed = 0;
     }
 }

--- a/server/src/main/java/net/wasicek/linkstub/services/LinkStubService.java
+++ b/server/src/main/java/net/wasicek/linkstub/services/LinkStubService.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 @Service
 public class LinkStubService {
 
-    private final static int MAX_NUM_USES = 10;
+    public static final int MAX_NUM_USES = 10;
 
     private LinkStubRepository linkStubRepository;
 

--- a/server/src/main/java/net/wasicek/linkstub/services/LinkStubService.java
+++ b/server/src/main/java/net/wasicek/linkstub/services/LinkStubService.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 @Service
 public class LinkStubService {
 
+    private final static int MAX_NUM_USES = 10;
+
     private LinkStubRepository linkStubRepository;
 
     @Autowired
@@ -26,13 +28,20 @@ public class LinkStubService {
     }
 
     public LinkStub createLinkStub(String originalUrl) {
-        LinkStub linkStubInDatabase;
-        Optional<LinkStub> searchResult = linkStubRepository.findByOriginalUrl(originalUrl);
-        if (searchResult.isEmpty()) {
-            linkStubInDatabase = linkStubRepository.save(new LinkStub(originalUrl));
-        } else {
-            linkStubInDatabase = searchResult.get();
-        }
-        return linkStubInDatabase;
+        return linkStubRepository.save(new LinkStub(originalUrl));
+    }
+
+    public boolean isLinkStubValid(LinkStub linkStub) {
+        return linkStub.getNumTimesUsed() < MAX_NUM_USES;
+    }
+
+    public void processLinkStubUse(LinkStub linkStub) {
+        linkStub.setNumTimesUsed(linkStub.getNumTimesUsed() + 1);
+        linkStubRepository.save(linkStub);
+    }
+
+    public void resetValidity(LinkStub linkStub) {
+        linkStub.setNumTimesUsed(0);
+        linkStubRepository.save(linkStub);
     }
 }


### PR DESCRIPTION
Keep track of the number of uses (i.e., redirects performed) of each Link Stub. After ten redirects a Link Stub becomes invalid unless/until it is recreated.