### PR TITLE
Shorten API length

### DIFF
--- a/client/src/components/linkstub-creator/LinkStubCreator.js
+++ b/client/src/components/linkstub-creator/LinkStubCreator.js
@@ -88,8 +88,8 @@ const LinkStubCreator = () => {
                 {urlHash && (
                     <Box>
                         <span>Stub: </span>
-                        <Link href={`${process.env.HOST}/api/${urlHash}`} target="_blank" rel="noreferrer">
-                            {`${process.env.HOST}/api/${urlHash}`}
+                        <Link href={`${process.env.HOST}/${urlHash}`} target="_blank" rel="noreferrer">
+                            {`${process.env.HOST}/${urlHash}`}
                         </Link>
                     </Box>
                 )}

--- a/client/src/services/linkstub/linkstub-service.js
+++ b/client/src/services/linkstub/linkstub-service.js
@@ -1,5 +1,5 @@
 const endpoints = {
-    CREATE_LINKSTUB: "api/linkstub",
+    CREATE_LINKSTUB: "linkstub",
 };
 
 const createLinkStub = async (linkStub) => {

--- a/server/src/main/java/net/wasicek/linkstub/config/DevCorsConfiguration.java
+++ b/server/src/main/java/net/wasicek/linkstub/config/DevCorsConfiguration.java
@@ -11,7 +11,7 @@ public class DevCorsConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**").allowedMethods(
+        registry.addMapping("/**").allowedMethods(
           "GET",
           "POST",
           "PUT",

--- a/server/src/main/java/net/wasicek/linkstub/controllers/LinkStubController.java
+++ b/server/src/main/java/net/wasicek/linkstub/controllers/LinkStubController.java
@@ -22,7 +22,6 @@ import java.net.URISyntaxException;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api")
 @Slf4j
 public class LinkStubController {
 
@@ -42,7 +41,7 @@ public class LinkStubController {
             // 201 if created new
             LinkStub saveResult = linkStubService.createLinkStub(linkStub.getOriginalUrl());
             response = ResponseEntity
-                    .created(new URI("/api/linkstub/" + saveResult.getUrlHash()))
+                    .created(new URI("/linkstub/" + saveResult.getUrlHash()))
                     .body(saveResult);
         } else {
             LinkStub foundStub = searchResult.get();
@@ -53,7 +52,7 @@ public class LinkStubController {
         return response;
     }
 
-    @GetMapping("/{urlHash}")
+    @GetMapping("/{urlHash:[a-zA-Z0-9]{8}}")
     public ResponseEntity<LinkStub> redirectLinkStub(@PathVariable String urlHash) throws URISyntaxException {
         Optional<LinkStub> searchResult = linkStubService.getLinkStubByHash(urlHash);
         ResponseEntity<LinkStub> response;


### PR DESCRIPTION
Removed /api/ from endpoints so that all the linkstub endpoints were on the same path and so that the overall path was shorter.